### PR TITLE
resolve attemtping to index first item in list

### DIFF
--- a/src/oic/oauth2/message.py
+++ b/src/oic/oauth2/message.py
@@ -319,7 +319,7 @@ class Message(MutableMapping):
 
             if isinstance(val, Message):
                 _res[key] = val.to_dict(lev + 1)
-            elif isinstance(val, list) and isinstance(val[0], Message):
+            elif isinstance(val, list) and isinstance(next(iter(val or []), None), Message):
                 _res[key] = [v.to_dict(lev) for v in val]
             else:
                 _res[key] = val


### PR DESCRIPTION
Fixes a problem in the sso-dashboard where the userinfo endpoint may return an empty list.  For example:  nicknames: []

This causes the to_dict method to set None instead of attempting val[0].  This would have been way easier in ruby thanks to .first() on list objects ;)
